### PR TITLE
Adding Transparent Background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "screenshot",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.0.3",
         "@radix-ui/react-label": "^2.0.1",
         "@radix-ui/react-radio-group": "^1.1.2",
         "@radix-ui/react-slider": "^1.1.1",
@@ -438,6 +439,26 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.3.tgz",
+      "integrity": "sha512-55B8/vKzTuzxllH5sGJO4zaBf9gYpJuJRRzaOKm+0oAefRnMvbf+Kgww7IOANVN0w3z7agFJgtnXaZl8Uj95AA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-previous": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -5176,6 +5197,22 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.2"
+      }
+    },
+    "@radix-ui/react-checkbox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.3.tgz",
+      "integrity": "sha512-55B8/vKzTuzxllH5sGJO4zaBf9gYpJuJRRzaOKm+0oAefRnMvbf+Kgww7IOANVN0w3z7agFJgtnXaZl8Uj95AA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-previous": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0"
       }
     },
     "@radix-ui/react-collection": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-label": "^2.0.1",
     "@radix-ui/react-radio-group": "^1.1.2",
     "@radix-ui/react-slider": "^1.1.1",

--- a/src/components/settings/Background.tsx
+++ b/src/components/settings/Background.tsx
@@ -1,7 +1,9 @@
 import { RadioGroup, RadioGroupItemCustom } from "@components/ui/RadioGroup";
-import { Settings } from "@config/defaults";
+import { Settings, defaultSettings } from "@config/defaults";
 import { Check } from "lucide-react";
 import { LabelTooltip } from "./LabelTooltip";
+import { cn } from "@utils/cn";
+import { Checkbox } from "@components/ui/Checkbox";
 
 const backgroundColors = [
   {
@@ -50,9 +52,23 @@ export const Background = ({
 }) => {
   return (
     <div className="mt-3 space-y-3">
-      <LabelTooltip tooltip="Quickly toggle using your arrow keys">
-        Background
-      </LabelTooltip>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="background"
+          checked={settings.backgroundColor !== "bg-transparent"}
+          onCheckedChange={(checked: boolean) =>
+            !checked
+              ? setBackgroundColor("bg-transparent")
+              : setBackgroundColor(defaultSettings.backgroundColor)
+          }
+        />
+        <LabelTooltip
+          htmlFor="background"
+          tooltip="Quickly toggle using your arrow keys"
+        >
+          Background
+        </LabelTooltip>
+      </div>
       <RadioGroup
         aria-label="Background Colors"
         className="grid grid-cols-3 gap-2"

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import { cn } from "@utils/cn";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-slate-100 ring-offset-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-100/25 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-100 data-[state=checked]:text-slate-900",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };


### PR DESCRIPTION
Thought that this would be the easiest way to add a transparent bg.

- The default is background enabled with the default background set
- If the user unchecks the background checkbox the background is set to `bg-transparent`
- If the user checks back the background checkbox the background is set to the default background

![Screenshot](https://github.com/webscopeio/screenshot/assets/77650775/53f7ee06-b15d-4fef-aaf0-6b65fd6528fa)
