### PR TITLE
Add `9/16` aspect ratio for mobile view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,6 +55,7 @@ export default function Home() {
                 className={`${cn(
                   "max-w-6xl max-h-[648px] grid place-items-center overflow-hidden",
                   settings.aspectRatio,
+                  settings.aspectRatio === "aspect-[9/16]" && "h-fit",
                   settings.aspectRatio === "aspect-[3/4]" && "h-fit",
                   settings.aspectRatio === "aspect-square" && "h-fit",
                   settings.aspectRatio === "aspect-video" && "w-full",

--- a/src/components/settings/AspectRatio.tsx
+++ b/src/components/settings/AspectRatio.tsx
@@ -15,6 +15,10 @@ const aspectRatios: { label: string; type: AspectRatioType }[] = [
   },
   {
     label: "3:4",
+    type: SUPPORTED_ASPECT_RATIOS.PHONE_WIDE,
+  },
+  {
+    label: "9:16",
     type: SUPPORTED_ASPECT_RATIOS.PHONE,
   },
   {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,6 +1,7 @@
 export const SUPPORTED_ASPECT_RATIOS = {
   VIDEO: "aspect-video",
-  PHONE: "aspect-[3/4]",
+  PHONE_WIDE: "aspect-[3/4]",
+  PHONE: "aspect-[9/16]",
   SQUARE: "aspect-square",
   AUTO: "aspect-auto",
 } as const;


### PR DESCRIPTION
I was using this library to make good-looking screenshots and I didn't find any problem with the aspect ratios for the horizontal ones, but the only vertical option currently is the `3/4`. For me, the most suitable vertical aspect ratio (mostly for mobile) is the `9/16` instead of the `3/4`.

I left the `3/4` aspect ratio in as I believe it does serve its purpose and just added the `9/16` ratio.

Maybe even allowing the user to enter their own desired aspect ratio would be a nice feature (or having a slider that can do that).